### PR TITLE
Add progress tracker to Word Complete

### DIFF
--- a/src/components/WordComplete.js
+++ b/src/components/WordComplete.js
@@ -145,9 +145,6 @@ function WordComplete({ text }) {
       <div className={styles.wordCompleteContainer}>
         {
           <>
-            <div className={styles.progress}>
-              Completed: {totalWords - asteriskedWords.length} | Remaining: {asteriskedWords.length}
-            </div>
             <div
               className={styles.textArea}
               onKeyUp={handleInput}
@@ -155,7 +152,9 @@ function WordComplete({ text }) {
             ></div>
             <div className={styles.mistakes}>{"✖".repeat(mistakes)}</div>
             <div className={styles.score}>
-              <span className={styles.star}>★</span> {score}
+              <span className={styles.star}>★</span> {score}&nbsp;&nbsp;&nbsp;
+              <span className={styles.todo}>📝 </span>
+              {asteriskedWords.length}
             </div>
           </>
         }

--- a/src/components/WordComplete.js
+++ b/src/components/WordComplete.js
@@ -2,15 +2,15 @@ import React, { useState, useEffect } from "react";
 import styles from "./WordComplete.module.css";
 
 function WordComplete({ text }) {
+  const initialWords = (text.match(/\*([a-zA-Z0-9]+)(?=[ ,.?!]|$)/g) || []).map(
+    (w) => w.substring(1)
+  );
+  const [totalWords] = useState(initialWords.length);
   const [originalText, setOriginalText] = useState(text);
   const [score, setScore] = useState(0);
   const [originalTextIndex, setOriginalTextIndex] = useState(0);
   const [displayedText, setDisplayedText] = useState(originalText);
-  const [asteriskedWords, setAsteriskedWords] = useState(
-    (originalText.match(/\*([a-zA-Z0-9]+)(?=[ ,.?!]|$)/g) || []).map((w) =>
-      w.substring(1)
-    )
-  );
+  const [asteriskedWords, setAsteriskedWords] = useState(initialWords);
   const [missingWordIndex, setMissingWordIndex] = useState(-1);
   const [mistakes, setMistakes] = useState(0);
   const [showCorrectWord, setShowCorrectWord] = useState(false);
@@ -145,6 +145,9 @@ function WordComplete({ text }) {
       <div className={styles.wordCompleteContainer}>
         {
           <>
+            <div className={styles.progress}>
+              Completed: {totalWords - asteriskedWords.length} | Remaining: {asteriskedWords.length}
+            </div>
             <div
               className={styles.textArea}
               onKeyUp={handleInput}

--- a/src/components/WordComplete.module.css
+++ b/src/components/WordComplete.module.css
@@ -13,6 +13,7 @@
   font-size: 1.2em;
   font-weight: bold;
   margin: 10px 0;
+  padding-top: 100px;
 }
 
 .textArea {
@@ -49,6 +50,12 @@
 
 .star {
   color: gold;
+  font-size: 2em;
+}
+
+.todo {
+  font-size: 1.4em;
+  color: gray;
 }
 
 .correctWordContainer {

--- a/src/components/WordComplete.module.css
+++ b/src/components/WordComplete.module.css
@@ -9,6 +9,12 @@
   border-radius: 20px;
 }
 
+.progress {
+  font-size: 1.2em;
+  font-weight: bold;
+  margin: 10px 0;
+}
+
 .textArea {
   font-size: 1.3em;
   font-family: "Arial", sans-serif;


### PR DESCRIPTION
## Summary
- track how many blanks are completed and remaining
- display progress above the Word Complete activity

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6843ef96db608322ac45cd032ff06e18