### PR TITLE
Trim inline-code padding for line-start [[...]] blocks in SelfReview

### DIFF
--- a/src/components/SelfReview.js
+++ b/src/components/SelfReview.js
@@ -17,7 +17,8 @@ const renderInlineMathText = (text, keyPrefix) => {
   );
 };
 
-const renderTextToken = (text, keyPrefix) => {
+const renderTextToken = (text, keyPrefix, options = {}) => {
+  const { trimCodePaddingStart = false, trimCodePaddingEnd = false } = options;
   const linkMatch = text.match(/^\[([^\]]+)\]\((https?:[^)]+)\)$/);
 
   if (linkMatch) {
@@ -48,8 +49,16 @@ const renderTextToken = (text, keyPrefix) => {
 
   const isCode = text.startsWith("[[") && text.endsWith("]]");
   if (isCode) {
+    const codeClassName = [
+      styles.inlineCode,
+      trimCodePaddingStart ? styles.inlineCodeTrimStart : "",
+      trimCodePaddingEnd ? styles.inlineCodeTrimEnd : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
     return (
-      <code key={`${keyPrefix}-code`} className={styles.inlineCode}>
+      <code key={`${keyPrefix}-code`} className={codeClassName}>
         {renderInlineMathText(text.slice(2, -2), `${keyPrefix}-code`)}
       </code>
     );
@@ -58,10 +67,22 @@ const renderTextToken = (text, keyPrefix) => {
   return renderInlineMathText(text, keyPrefix);
 };
 
-const renderFormattedText = (text) =>
-  text.split(tokenPattern).filter(Boolean).map((segment, index) =>
-    renderTextToken(segment, `segment-${index}`),
-  );
+const renderFormattedText = (text) => {
+  const segments = text.split(tokenPattern).filter(Boolean);
+
+  return segments.map((segment, index) => {
+    const previousSegment = segments[index - 1] || "";
+    const nextSegment = segments[index + 1] || "";
+    const isCode = segment.startsWith("[[") && segment.endsWith("]]");
+
+    return renderTextToken(segment, `segment-${index}`, {
+      trimCodePaddingStart:
+        isCode && (index === 0 || previousSegment.endsWith("\n")),
+      trimCodePaddingEnd:
+        isCode && (index === segments.length - 1 || nextSegment.startsWith("\n")),
+    });
+  });
+};
 
 const FormattedText = ({ text, className }) => (
   <div className={className}>{renderFormattedText(text)}</div>

--- a/src/components/SelfReview.module.css
+++ b/src/components/SelfReview.module.css
@@ -313,6 +313,14 @@
   border-radius: 4px;
 }
 
+.inlineCodeTrimStart {
+  padding-left: 0;
+}
+
+.inlineCodeTrimEnd {
+  padding-right: 0;
+}
+
 .celebration {
   position: fixed;
   top: 20%;

--- a/src/components/SelfReview.test.js
+++ b/src/components/SelfReview.test.js
@@ -6,6 +6,7 @@ import SelfReview, {
   getQuestionScore,
   parseSelfReviewText,
 } from "./SelfReview";
+import styles from "./SelfReview.module.css";
 
 describe("parseSelfReviewText", () => {
   it("parses multiline questions and latex before the marks line", () => {
@@ -102,6 +103,36 @@ describe("formatted self-review rendering", () => {
       root.unmount();
     });
     container.remove();
+  });
+
+  it("trims inline code side padding when a [[...]] block starts or ends on its own line", () => {
+    act(() => {
+      root.render(
+        <SelfReview
+          text={`Topic
+
+Explain the output
+[[line 1
+line 2]]
+Then reference [[inline example]] in a sentence.
+1
+Method shown`}
+        />,
+      );
+    });
+
+    const codes = Array.from(container.querySelectorAll("code"));
+    const blockCode = codes.find((node) => node.textContent?.includes("line 1"));
+    const inlineCode = codes.find((node) => node.textContent === "inline example");
+
+    expect(blockCode).toBeTruthy();
+    expect(blockCode.className).toContain(styles.inlineCodeTrimStart);
+    expect(blockCode.className).toContain(styles.inlineCodeTrimEnd);
+
+    expect(inlineCode).toBeTruthy();
+    expect(inlineCode.className).toContain(styles.inlineCode);
+    expect(inlineCode.className).not.toContain(styles.inlineCodeTrimStart);
+    expect(inlineCode.className).not.toContain(styles.inlineCodeTrimEnd);
   });
 
   it("renders highlighted text, markdown links, and inline code in question and markscheme text", () => {


### PR DESCRIPTION
### Motivation
- Equal-spaced blocks written with the `[[...]]` token were rendered with an extra space when the token started on its own line, causing the first line of multiline blocks to misalign with subsequent lines.
- The formatter must keep the inline spacing behaviour for code embedded in text while removing the unwanted side padding when a `[[...]]` block appears at a line boundary.

### Description
- Make `renderFormattedText` detect `[[...]]` tokens that start or end on a line boundary and pass trimming hints into `renderTextToken` via `trimCodePaddingStart` and `trimCodePaddingEnd` options.
- Apply those options in `renderTextToken` to add CSS modifier classes (`inlineCodeTrimStart` and `inlineCodeTrimEnd`) that remove left/right padding for boundary code blocks.
- Add the new CSS rules to `SelfReview.module.css` to zero the left or right padding when the modifiers are present.
- Add a regression test in `SelfReview.test.js` that covers a standalone multiline `[[...]]` block and an inline `[[...]]` example to ensure both behaviours remain correct.

### Testing
- Ran the component test suite with `CI=1 npm test -- --runInBand --watch=false src/components/SelfReview.test.js`, and all tests passed (7/7).
- The new regression test verifies that a block `[[...]]` at a line boundary receives the trimming classes and that inline `[[...]]` tokens keep their normal padding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1b7003c288322b55de6495329d833)