### PR TITLE
Enhance SelfReview: quick-jump, next button, retry, and local persistence

### DIFF
--- a/src/components/SelfReview.js
+++ b/src/components/SelfReview.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { InlineMath } from "react-katex";
 import styles from "./SelfReview.module.css";
 import MathComponent from "./MathComponent";
@@ -47,7 +47,7 @@ const renderTextToken = (text, keyPrefix, options = {}) => {
     );
   }
 
-  const isCode = text.startsWith("[[") && text.endsWith("]]");
+  const isCode = text.startsWith("[[") && text.endsWith("]]" );
   if (isCode) {
     const codeClassName = [
       styles.inlineCode,
@@ -73,7 +73,7 @@ const renderFormattedText = (text) => {
   return segments.map((segment, index) => {
     const previousSegment = segments[index - 1] || "";
     const nextSegment = segments[index + 1] || "";
-    const isCode = segment.startsWith("[[") && segment.endsWith("]]");
+    const isCode = segment.startsWith("[[") && segment.endsWith("]]" );
 
     return renderTextToken(segment, `segment-${index}`, {
       trimCodePaddingStart:
@@ -232,12 +232,42 @@ const QuestionNavigator = ({
   currentQuestionIndex,
   isReviewMode,
   onSelectQuestion,
+  onNextQuestion,
   onEndReview,
+  onClearAll,
 }) => (
   <aside className={styles.navigatorPanel}>
     <div className={styles.navigatorHeader}>Question navigator</div>
     <div className={styles.navigatorMode}>
       {isReviewMode ? "Review mode" : "Answer mode"}
+    </div>
+    <div className={styles.quickNavRow}>
+      <label htmlFor="question-jump" className={styles.quickNavLabel}>
+        Jump to
+      </label>
+      <div className={styles.quickNavControls}>
+        <select
+          id="question-jump"
+          className={styles.questionSelect}
+          value={currentQuestionIndex}
+          onChange={(event) => onSelectQuestion(parseInt(event.target.value, 10))}
+        >
+          {questions.map((question, index) => (
+            <option key={`${question.text}-${index}`} value={index}>
+              Question {index + 1}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className={styles.nextQuestionButton}
+          onClick={onNextQuestion}
+          disabled={currentQuestionIndex >= questions.length - 1}
+          aria-label="Go to next question"
+        >
+          &gt;
+        </button>
+      </div>
     </div>
     <div className={styles.navigatorList}>
       {questions.map((question, index) => {
@@ -271,6 +301,16 @@ const QuestionNavigator = ({
     >
       END REVIEW
     </button>
+    <button
+      type="button"
+      onClick={onClearAll}
+      className={styles.clearAllButton}
+    >
+      Clear All Progress
+    </button>
+    <div className={styles.clearAllWarning}>
+      Warning: this removes all saved answers and review choices for this self-review.
+    </div>
   </aside>
 );
 
@@ -327,6 +367,35 @@ export const parseSelfReviewText = (value) => {
 
 export { getMarkschemePointValue, getQuestionScore };
 
+const buildStorageKey = (reviewTitle) => `self-review-state:${reviewTitle || "untitled"}`;
+
+const isStoredStateCompatible = (parsedQuestions, storedQuestions) => {
+  if (!Array.isArray(storedQuestions) || storedQuestions.length !== parsedQuestions.length) {
+    return false;
+  }
+
+  return storedQuestions.every((storedQuestion, index) => {
+    const parsedQuestion = parsedQuestions[index];
+
+    if (storedQuestion?.text !== parsedQuestion.text) {
+      return false;
+    }
+
+    if (!Array.isArray(storedQuestion?.markscheme)) {
+      return false;
+    }
+
+    if (storedQuestion.markscheme.length !== parsedQuestion.markscheme.length) {
+      return false;
+    }
+
+    return storedQuestion.markscheme.every(
+      (storedPoint, pointIndex) =>
+        storedPoint?.text === parsedQuestion.markscheme[pointIndex]?.text,
+    );
+  });
+};
+
 const SelfReview = ({ text }) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [questions, setQuestions] = useState([]);
@@ -334,15 +403,74 @@ const SelfReview = ({ text }) => {
   const [isReviewMode, setIsReviewMode] = useState(false);
   const [isReviewStage, setIsReviewStage] = useState(false);
 
+  const storageKey = useMemo(() => buildStorageKey(title), [title]);
+
   useEffect(() => {
     const { title: parsedTitle, questions: parsedQuestions } =
       parseSelfReviewText(text);
     setTitle(parsedTitle);
-    setQuestions(parsedQuestions);
-    setCurrentQuestionIndex(0);
-    setIsReviewMode(false);
-    setIsReviewStage(false);
+
+    const nextStorageKey = buildStorageKey(parsedTitle);
+    const storedStateRaw = window.localStorage.getItem(nextStorageKey);
+
+    if (!storedStateRaw) {
+      setQuestions(parsedQuestions);
+      setCurrentQuestionIndex(0);
+      setIsReviewMode(false);
+      setIsReviewStage(false);
+      return;
+    }
+
+    try {
+      const storedState = JSON.parse(storedStateRaw);
+
+      if (!isStoredStateCompatible(parsedQuestions, storedState.questions)) {
+        setQuestions(parsedQuestions);
+        setCurrentQuestionIndex(0);
+        setIsReviewMode(false);
+        setIsReviewStage(false);
+        return;
+      }
+
+      const safeQuestionIndex = Math.min(
+        Math.max(storedState.currentQuestionIndex ?? 0, 0),
+        Math.max(parsedQuestions.length - 1, 0),
+      );
+
+      setQuestions(storedState.questions);
+      setCurrentQuestionIndex(safeQuestionIndex);
+      setIsReviewMode(Boolean(storedState.isReviewMode));
+      setIsReviewStage(Boolean(storedState.isReviewStage));
+    } catch {
+      setQuestions(parsedQuestions);
+      setCurrentQuestionIndex(0);
+      setIsReviewMode(false);
+      setIsReviewStage(false);
+    }
   }, [text]);
+
+  useEffect(() => {
+    if (!title || questions.length === 0) {
+      return;
+    }
+
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        questions,
+        currentQuestionIndex,
+        isReviewMode,
+        isReviewStage,
+      }),
+    );
+  }, [
+    currentQuestionIndex,
+    isReviewMode,
+    isReviewStage,
+    questions,
+    storageKey,
+    title,
+  ]);
 
   const showSummary = () => {
     setIsReviewStage(true);
@@ -358,6 +486,12 @@ const SelfReview = ({ text }) => {
   const advanceToQuestion = (index) => {
     setCurrentQuestionIndex(index);
     setIsReviewMode(questions[index]?.reviewed ?? false);
+  };
+
+  const handleNextQuestion = () => {
+    if (currentQuestionIndex < questions.length - 1) {
+      handleSelectQuestion(currentQuestionIndex + 1);
+    }
   };
 
   const toggleReviewMode = () => {
@@ -409,6 +543,47 @@ const SelfReview = ({ text }) => {
     );
   };
 
+  const handleRetryQuestion = () => {
+    setQuestions((prevQuestions) =>
+      prevQuestions.map((question, index) => {
+        if (index !== currentQuestionIndex) {
+          return question;
+        }
+
+        return {
+          ...question,
+          answer: "",
+          reviewed: false,
+          markscheme: question.markscheme.map((point) => ({
+            ...point,
+            selected: false,
+          })),
+        };
+      }),
+    );
+    setIsReviewMode(false);
+    setIsReviewStage(false);
+  };
+
+  const handleClearAllProgress = () => {
+    const userConfirmed = window.confirm(
+      "Clear all saved self-review progress for this activity?",
+    );
+
+    if (!userConfirmed) {
+      return;
+    }
+
+    const { title: parsedTitle, questions: parsedQuestions } =
+      parseSelfReviewText(text);
+    window.localStorage.removeItem(buildStorageKey(parsedTitle));
+    setTitle(parsedTitle);
+    setQuestions(parsedQuestions);
+    setCurrentQuestionIndex(0);
+    setIsReviewMode(false);
+    setIsReviewStage(false);
+  };
+
   return (
     <>
       <h1 className={styles.interactiveSubTitle}>{title}</h1>
@@ -441,24 +616,37 @@ const SelfReview = ({ text }) => {
                   </div>
                 </>
               )}
-              <button
-                type="button"
-                onClick={toggleReviewMode}
-                className={styles.reviewButton}
-              >
-                {isReviewMode && currentQuestionIndex < questions.length - 1
-                  ? "Next"
-                  : isReviewMode
-                    ? "Review Summary"
-                    : "Review"}
-              </button>
+              <div className={styles.actionButtonsRow}>
+                <button
+                  type="button"
+                  onClick={toggleReviewMode}
+                  className={styles.reviewButton}
+                >
+                  {isReviewMode && currentQuestionIndex < questions.length - 1
+                    ? "Next"
+                    : isReviewMode
+                      ? "Review Summary"
+                      : "Review"}
+                </button>
+                {isReviewMode && (
+                  <button
+                    type="button"
+                    onClick={handleRetryQuestion}
+                    className={styles.retryButton}
+                  >
+                    Retry
+                  </button>
+                )}
+              </div>
             </div>
             <QuestionNavigator
               questions={questions}
               currentQuestionIndex={currentQuestionIndex}
               isReviewMode={isReviewMode}
               onSelectQuestion={handleSelectQuestion}
+              onNextQuestion={handleNextQuestion}
               onEndReview={showSummary}
+              onClearAll={handleClearAllProgress}
             />
           </div>
         )}

--- a/src/components/SelfReview.js
+++ b/src/components/SelfReview.js
@@ -368,6 +368,7 @@ export const parseSelfReviewText = (value) => {
 export { getMarkschemePointValue, getQuestionScore };
 
 const buildStorageKey = (reviewTitle) => `self-review-state:${reviewTitle || "untitled"}`;
+const SELF_REVIEW_STATE_TTL_MS = 1000 * 60 * 60 * 24 * 365;
 
 const isStoredStateCompatible = (parsedQuestions, storedQuestions) => {
   if (!Array.isArray(storedQuestions) || storedQuestions.length !== parsedQuestions.length) {
@@ -424,6 +425,19 @@ const SelfReview = ({ text }) => {
     try {
       const storedState = JSON.parse(storedStateRaw);
 
+      const isExpired =
+        typeof storedState.expiresAt !== "number" ||
+        storedState.expiresAt <= Date.now();
+
+      if (isExpired) {
+        window.localStorage.removeItem(nextStorageKey);
+        setQuestions(parsedQuestions);
+        setCurrentQuestionIndex(0);
+        setIsReviewMode(false);
+        setIsReviewStage(false);
+        return;
+      }
+
       if (!isStoredStateCompatible(parsedQuestions, storedState.questions)) {
         setQuestions(parsedQuestions);
         setCurrentQuestionIndex(0);
@@ -461,6 +475,7 @@ const SelfReview = ({ text }) => {
         currentQuestionIndex,
         isReviewMode,
         isReviewStage,
+        expiresAt: Date.now() + SELF_REVIEW_STATE_TTL_MS,
       }),
     );
   }, [
@@ -584,12 +599,24 @@ const SelfReview = ({ text }) => {
     setIsReviewStage(false);
   };
 
+  const handleGoBackFromSummary = () => {
+    setIsReviewStage(false);
+    setIsReviewMode(questions[currentQuestionIndex]?.reviewed ?? false);
+  };
+
   return (
     <>
       <h1 className={styles.interactiveSubTitle}>{title}</h1>
       <div className={styles.selfReview}>
         {isReviewStage ? (
           <>
+            <button
+              type="button"
+              onClick={handleGoBackFromSummary}
+              className={styles.goBackButton}
+            >
+              Go Back
+            </button>
             <div className={styles.celebration}>😃</div>
             <ReviewDisplay questions={questions} />
           </>

--- a/src/components/SelfReview.module.css
+++ b/src/components/SelfReview.module.css
@@ -10,6 +10,21 @@
   padding: 20px;
 }
 
+.goBackButton {
+  margin-bottom: 12px;
+  padding: 8px 14px;
+  color: #fff;
+  background-color: #2f4858;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95em;
+}
+
+.goBackButton:hover {
+  background-color: #243946;
+}
+
 .exerciseLayout {
   display: flex;
   align-items: flex-start;

--- a/src/components/SelfReview.module.css
+++ b/src/components/SelfReview.module.css
@@ -123,8 +123,18 @@
   background: #fff;
 }
 
+.actionButtonsRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
 .reviewButton,
-.endReviewButton {
+.endReviewButton,
+.retryButton,
+.nextQuestionButton,
+.clearAllButton {
   padding: 10px 20px;
   color: white;
   border: none;
@@ -140,6 +150,15 @@
 
 .reviewButton:hover {
   background-color: #0056b3;
+}
+
+.retryButton {
+  margin-top: 20px;
+  background-color: #6c757d;
+}
+
+.retryButton:hover {
+  background-color: #565e64;
 }
 
 .endReviewButton {
@@ -177,6 +196,54 @@
 .navigatorMode {
   font-size: 0.9em;
   color: #666;
+}
+
+.quickNavRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.quickNavLabel {
+  font-size: 0.78em;
+  color: #667085;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.quickNavControls {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.questionSelect {
+  width: 100%;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid #ccd4dd;
+  border-radius: 8px;
+  background: #fff;
+  color: #1f2a37;
+}
+
+.nextQuestionButton {
+  min-width: 32px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background-color: #007bff;
+  font-weight: 700;
+}
+
+.nextQuestionButton:hover {
+  background-color: #0056b3;
+}
+
+.nextQuestionButton:disabled {
+  background-color: #9eb9dd;
+  cursor: not-allowed;
 }
 
 .navigatorList {
@@ -224,6 +291,22 @@
 .navigatorItemStatus {
   font-size: 0.82em;
   color: #555;
+}
+
+.clearAllButton {
+  width: 100%;
+  background-color: #b3261e;
+  margin-top: 6px;
+}
+
+.clearAllButton:hover {
+  background-color: #8d1f19;
+}
+
+.clearAllWarning {
+  font-size: 0.78em;
+  color: #7a2e2a;
+  line-height: 1.3;
 }
 
 .reviewDisplay {

--- a/src/components/SelfReview.test.js
+++ b/src/components/SelfReview.test.js
@@ -93,6 +93,7 @@ describe("formatted self-review rendering", () => {
   let root;
 
   beforeEach(() => {
+    window.localStorage.clear();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -206,5 +207,93 @@ Supports [reference link](https://example.com/markscheme)`}
       "https://example.com/markscheme",
     );
     expect(markschemeLink.getAttribute("target")).toBe("_blank");
+  });
+
+  it("shows retry in review mode and clears answer + selected markscheme points", () => {
+    act(() => {
+      root.render(
+        <SelfReview
+          text={`Topic
+
+Question one
+2
+Point A
+Point B`}
+        />,
+      );
+    });
+
+    const textarea = container.querySelector("textarea");
+    act(() => {
+      Simulate.change(textarea, { target: { value: "My answer" } });
+    });
+
+    const reviewButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Review",
+    );
+
+    act(() => {
+      Simulate.click(reviewButton);
+    });
+
+    const firstPoint = container.querySelector('[class*="markschemePoint"]');
+    act(() => {
+      Simulate.click(firstPoint);
+    });
+
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Retry",
+    );
+
+    act(() => {
+      Simulate.click(retryButton);
+    });
+
+    expect(container.querySelector("textarea").value).toBe("");
+    expect(
+      container.querySelectorAll('[class*="markschemePoint"]').length,
+    ).toBe(0);
+  });
+
+  it("restores persisted answers and selected markscheme points from localStorage", () => {
+    const text = `Topic
+
+Question one
+2
+Point A
+Point B`;
+
+    act(() => {
+      root.render(<SelfReview text={text} />);
+    });
+
+    act(() => {
+      Simulate.change(container.querySelector("textarea"), {
+        target: { value: "Stored answer" },
+      });
+    });
+
+    const reviewButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Review",
+    );
+
+    act(() => {
+      Simulate.click(reviewButton);
+    });
+
+    const firstPoint = container.querySelector('[class*="markschemePoint"]');
+    act(() => {
+      Simulate.click(firstPoint);
+    });
+
+    act(() => {
+      root.unmount();
+      root = createRoot(container);
+      root.render(<SelfReview text={text} />);
+    });
+
+    expect(container.querySelector("textarea").value).toBe("Stored answer");
+    const selectedPoint = container.querySelector(`.${styles.selected}`);
+    expect(selectedPoint).toBeTruthy();
   });
 });

--- a/src/components/SelfReview.test.js
+++ b/src/components/SelfReview.test.js
@@ -296,4 +296,77 @@ Point B`;
     const selectedPoint = container.querySelector(`.${styles.selected}`);
     expect(selectedPoint).toBeTruthy();
   });
+
+  it("shows a go back button on summary screen and returns to question view", () => {
+    const text = `Topic
+
+Question one
+1
+Point A`;
+
+    act(() => {
+      root.render(<SelfReview text={text} />);
+    });
+
+    const reviewButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Review",
+    );
+    act(() => {
+      Simulate.click(reviewButton);
+    });
+
+    const summaryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Review Summary",
+    );
+    act(() => {
+      Simulate.click(summaryButton);
+    });
+
+    const goBackButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Go Back",
+    );
+    expect(goBackButton).toBeTruthy();
+
+    act(() => {
+      Simulate.click(goBackButton);
+    });
+
+    expect(container.querySelector("textarea")).toBeTruthy();
+  });
+
+  it("does not restore expired localStorage state", () => {
+    const text = `Topic
+
+Question one
+1
+Point A`;
+
+    window.localStorage.setItem(
+      "self-review-state:Topic",
+      JSON.stringify({
+        questions: [
+          {
+            text: "1. Question one",
+            marks: 1,
+            markscheme: [{ text: "Point A", selected: true }],
+            answer: "Old answer",
+            reviewed: true,
+          },
+        ],
+        currentQuestionIndex: 0,
+        isReviewMode: true,
+        isReviewStage: false,
+        expiresAt: Date.now() - 1000,
+      }),
+    );
+
+    act(() => {
+      root.render(<SelfReview text={text} />);
+    });
+
+    expect(container.querySelector("textarea").value).toBe("");
+    expect(window.localStorage.getItem("self-review-state:Topic")).toContain(
+      "\"answer\":\"\"",
+    );
+  });
 });


### PR DESCRIPTION
### Motivation

- Improve navigation so learners can jump directly to questions or step forward quickly while working through a self-review.
- Let learners retry an individual question during review without losing the rest of their progress.
- Prevent accidental loss of work by persisting answers and review selections across page refreshes and revisits.

### Description

- Added a quick-jump dropdown and compact blue `>` next-question button to the top of the question navigator and wired them to the same selection flow as the existing navigator list (changes in `src/components/SelfReview.js` and styles in `src/components/SelfReview.module.css`).
- Added a `Retry` button that appears during review which clears the current question's `answer` and deselects its markscheme points and returns that question to answer mode (`handleRetryQuestion` in `SelfReview.js`).
- Implemented browser persistence scoped to the self-review title using `localStorage`, with a storage key builder and compatibility check to ensure stored state matches the parsed question structure before restoring (build/restore logic in `SelfReview.js`).
- Added a `Clear All Progress` button and user-facing warning that removes the stored state for the current self-review title and resets in-memory state, plus supporting CSS and test updates (`SelfReview.module.css`, `SelfReview.test.js`).

### Testing

- Ran the focused unit tests with `npm test -- --watch=false --runInBand src/components/SelfReview.test.js` and the suite passed.
- Test results: 1 test suite passed with 9 tests and all expectations succeeding (covers parsing, formatting, retry/reset behavior, and `localStorage` restore).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c4594f26e88322aa0c46079a5cd921)